### PR TITLE
Add ASAN build rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,12 +7,30 @@ Standards-Version: 1.0.0
 
 Package: swss
 Architecture: any
+Build-Profiles: <!asan>
 Depends: ${shlibs:Depends}
+Conflicts: swss-asan
 Description: This package contains Switch State Service for SONiC project.
 
 Package: swss-dbg
 Architecture: any
+Build-Profiles: <!asan>
 Section: debug
 Priority: extra
 Depends: swss (=${binary:Version})
 Description: debugging symbols for swss
+
+Package: swss-asan
+Architecture: any
+Build-Profiles: <asan>
+Depends: ${shlibs:Depends}
+Conflicts: swss
+Description: This package contains ASAN-instrumented Switch State Service for SONiC project.
+
+Package: swss-dbg-asan
+Architecture: any
+Build-Profiles: <asan>
+Section: debug
+Priority: extra
+Depends: swss-asan (=${binary:Version})
+Description: debugging symbols for swss-asan

--- a/debian/rules
+++ b/debian/rules
@@ -28,7 +28,7 @@ include /usr/share/dpkg/default.mk
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 configure_opts =
-ifeq ($(ENABLE_ASAN), y)
+ifneq ($(filter asan,$(DEB_BUILD_PROFILES)),)
 	configure_opts += --enable-asan
 endif
 
@@ -44,14 +44,22 @@ override_dh_auto_build:
 	# Build and test countersyncd Rust project
 	cargo build --release --locked
 
+ifneq ($(filter asan,$(DEB_BUILD_PROFILES)),)
+SWSS_PKG = swss-asan
+SWSS_DBG_PKG = swss-dbg-asan
+else
+SWSS_PKG = swss
+SWSS_DBG_PKG = swss-dbg
+endif
+
 override_dh_auto_install:
-	dh_auto_install --destdir=debian/swss
+	dh_auto_install --destdir=debian/$(SWSS_PKG)
 ifeq ($(ENABLE_GCOV), y)
-	mkdir -p debian/swss/tmp/gcov
+	mkdir -p debian/$(SWSS_PKG)/tmp/gcov
 	lcov -c --directory . --no-external --exclude "$(shell pwd)/tests/*" --exclude "$(shell pwd)/**/tests/*" --ignore-errors gcov --output-file coverage.info
 	lcov --add-tracefile coverage.info -o coverage.info
 	lcov_cobertura coverage.info -o coverage.xml
-	find ./ -type f -regex '.*\.\(h\|cpp\|gcno\|info\)' | tar -cf debian/swss/tmp/gcov/gcov-source.tar -T -
+	find ./ -type f -regex '.*\.\(h\|cpp\|gcno\|info\)' | tar -cf debian/$(SWSS_PKG)/tmp/gcov/gcov-source.tar -T -
 endif
 
 override_dh_auto_clean:
@@ -60,4 +68,4 @@ override_dh_auto_clean:
 	cargo clean || true
 
 override_dh_strip:
-	dh_strip --dbg-package=swss-dbg
+	dh_strip -p$(SWSS_PKG) --dbg-package=$(SWSS_DBG_PKG)

--- a/debian/swss-asan.install
+++ b/debian/swss-asan.install
@@ -1,0 +1,4 @@
+swssconfig/sample/netbouncer.json etc/swss/config.d
+neighsyncd/restore_neighbors.py usr/bin
+fpmsyncd/bgp_eoiu_marker.py usr/bin
+target/release/countersyncd usr/bin


### PR DESCRIPTION
Adds a separate ASAN swss build package to be created as the target when DEB_BUILD_PROFILES=asan. This is required for Clobbering of ASAN after a standard swss build on the same build machine.